### PR TITLE
Add professional company-style homepage for Finsathi

### DIFF
--- a/accounting/static/css/company_home.css
+++ b/accounting/static/css/company_home.css
@@ -1,0 +1,34 @@
+:root {
+  --bg: #0f172a;
+  --text: #0f172a;
+  --muted: #475569;
+  --light: #f8fafc;
+  --brand: #2563eb;
+}
+* { box-sizing: border-box; }
+body { margin: 0; font-family: Inter, Arial, sans-serif; color: var(--text); background: #fff; line-height: 1.6; }
+.container { width: min(1100px, 92%); margin: 0 auto; }
+.topbar { background: #fff; border-bottom: 1px solid #e2e8f0; position: sticky; top: 0; }
+.nav { display: flex; justify-content: space-between; align-items: center; padding: 14px 0; }
+.brand { margin: 0; font-size: 1.3rem; color: var(--brand); }
+nav a { text-decoration: none; margin-left: 20px; color: #334155; }
+.hero { background: linear-gradient(145deg, #eff6ff, #f8fafc); padding: 72px 0; }
+.hero-grid { display: grid; grid-template-columns: 1.2fr .8fr; gap: 28px; align-items: start; }
+.tag { color: var(--brand); font-weight: 700; letter-spacing: .04em; }
+h2 { font-size: 2.6rem; line-height: 1.2; margin: 0 0 16px; }
+.subtitle { color: var(--muted); max-width: 620px; }
+.actions { margin-top: 26px; display: flex; gap: 12px; }
+.btn { background: var(--brand); color: #fff; padding: 10px 18px; border-radius: 8px; text-decoration: none; font-weight: 600; display: inline-block; }
+.btn-outline { border: 1px solid #cbd5e1; color: #0f172a; background: #fff; }
+.btn-ghost { background: #1e293b; }
+.card { background: #fff; border: 1px solid #dbeafe; border-radius: 12px; padding: 22px; box-shadow: 0 10px 30px rgba(15, 23, 42, .08); }
+.section { padding: 64px 0; }
+.grid { display: grid; grid-template-columns: repeat(4,1fr); gap: 16px; }
+.grid article { border: 1px solid #e2e8f0; border-radius: 10px; padding: 18px; background: #fff; }
+.section-dark { background: var(--bg); color: var(--light); }
+.footer { background: #020617; color: #cbd5e1; padding: 30px 0; }
+@media (max-width: 900px) {
+  .hero-grid, .grid { grid-template-columns: 1fr; }
+  nav a { margin-left: 10px; }
+  h2 { font-size: 2rem; }
+}

--- a/accounting/templates/company_home.html
+++ b/accounting/templates/company_home.html
@@ -1,0 +1,70 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Finsathi | Modern Accounting Platform</title>
+    <link rel="stylesheet" href="{% static 'css/company_home.css' %}">
+</head>
+<body>
+    <header class="topbar">
+        <div class="container nav">
+            <h1 class="brand">Finsathi</h1>
+            <nav>
+                <a href="#features">Features</a>
+                <a href="#solutions">Solutions</a>
+                <a href="#contact">Contact</a>
+                <a class="btn btn-outline" href="/admin/">Admin</a>
+            </nav>
+        </div>
+    </header>
+
+    <section class="hero">
+        <div class="container hero-grid">
+            <div>
+                <p class="tag">Accounting • Inventory • Cashflow</p>
+                <h2>Finance operations built for growing businesses.</h2>
+                <p class="subtitle">Finsathi helps teams manage purchases, sales, party ledgers, cash/bank transactions, and stock from one reliable system.</p>
+                <div class="actions">
+                    <a href="/admin/" class="btn">Get Started</a>
+                    <a href="/api/" class="btn btn-ghost">Explore API</a>
+                </div>
+            </div>
+            <div class="card">
+                <h3>What you can run daily</h3>
+                <ul>
+                    <li>Record sales and purchases</li>
+                    <li>Track receivables and payables</li>
+                    <li>Maintain inventory in real time</li>
+                    <li>Generate ledger and statements</li>
+                </ul>
+            </div>
+        </div>
+    </section>
+
+    <section id="features" class="section container">
+        <h3>Core Capabilities</h3>
+        <div class="grid">
+            <article><h4>Ledger Automation</h4><p>Running balances are updated automatically for every transaction.</p></article>
+            <article><h4>Inventory Control</h4><p>Stock quantities adjust with each sale and purchase entry.</p></article>
+            <article><h4>Cash & Bank</h4><p>Manage account-level cashflows across payment modes.</p></article>
+            <article><h4>Secure Admin</h4><p>Use Django Admin to manage data with role-based access.</p></article>
+        </div>
+    </section>
+
+    <section id="solutions" class="section section-dark">
+        <div class="container">
+            <h3>Built for professional finance workflows</h3>
+            <p>Whether you run a trading company, distribution business, or service enterprise, Finsathi gives your team a dependable accounting backbone.</p>
+        </div>
+    </section>
+
+    <footer id="contact" class="footer">
+        <div class="container">
+            <p><strong>Finsathi</strong> — Streamline your accounting operations.</p>
+            <p>Contact: support@finsathi.com</p>
+        </div>
+    </footer>
+</body>
+</html>

--- a/accounting/views.py
+++ b/accounting/views.py
@@ -1,6 +1,12 @@
+from django.shortcuts import render
 from rest_framework import viewsets
+
 from .models import SalePurchase, CashBankTransaction
 from .serializers import SalePurchaseSerializer, CashBankTransactionSerializer
+
+
+def company_home(request):
+    return render(request, "company_home.html")
 
 
 class SalePurchaseViewSet(viewsets.ModelViewSet):

--- a/accounting_project/urls.py
+++ b/accounting_project/urls.py
@@ -1,23 +1,10 @@
-"""
-URL configuration for accounting_project project.
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/6.0/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
-"""
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import include, path
+
+from accounting.views import company_home
 
 urlpatterns = [
+    path('', company_home, name='company-home'),
     path('admin/', admin.site.urls),
     path('api/', include('accounting.urls')),
 ]


### PR DESCRIPTION
### Motivation
- Provide a public-facing, professional landing page so the project can present itself as a company/product instead of admin/API-only.
- Surface core capabilities, calls-to-action to the admin and API, and a simple contact footer for users evaluating the project.

### Description
- Added a `company_home` view that renders the new landing page in `accounting/views.py` using `render` and the Django template system.
- Added a marketing-oriented template at `accounting/templates/company_home.html` with header/navigation, hero, features, solutions, and contact footer sections.
- Added a dedicated stylesheet `accounting/static/css/company_home.css` with responsive layout, branding tokens, and polished UI styles.
- Routed the site root to the new homepage by updating `accounting_project/urls.py` to include `path('', company_home, name='company-home')` while keeping existing `admin/` and `api/` routes.

### Testing
- Ran `python manage.py check` to validate the Django project configuration, which failed due to the runtime environment missing Django (`ModuleNotFoundError: No module named 'django'`).
- No other automated tests were executed in this environment; template and static assets are added and should be validated in a local/dev environment with Django installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc9ef32ca483228277d41f8a8a94f4)