### PR TITLE
Add explicit `index.html` redirect to homepage to fix Appwrite 404

### DIFF
--- a/accounting_project/urls.py
+++ b/accounting_project/urls.py
@@ -6,6 +6,7 @@ from accounting.views import company_home, health_check
 
 urlpatterns = [
     path('', company_home, name='company-home'),
+    path('index.html', RedirectView.as_view(pattern_name='company-home', permanent=False)),
     path('health/', health_check, name='health-check'),
     path('admin/', admin.site.urls),
     path('api/', include('accounting.urls')),


### PR DESCRIPTION
### Motivation
- Some Appwrite deployments (or their edge/default document handling) request `/index.html`, which previously produced a “page not found” experience even though `/` is valid, so an explicit `index.html` route is needed to redirect to the homepage.

### Description
- Added `path('index.html', RedirectView.as_view(pattern_name='company-home', permanent=False))` to `accounting_project/urls.py` to redirect requests for `/index.html` to the existing `company-home` view.

### Testing
- Ran `python manage.py check` but it failed due to the local environment missing Django (`ModuleNotFoundError: No module named 'django'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcb3adf27483228c29039f6f97dbef)